### PR TITLE
Add build Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Don't copy these files into the Docker image.
+build
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# A dockerfile to build and run tests (and you can extract binaries from here too).
+# $ docker build .
+FROM silkeh/clang
+
+WORKDIR /app
+
+# Install required bison, flex
+# valgrind for testing.
+RUN apt-get update \
+    && apt-get install -y bison flex valgrind
+
+COPY . .
+
+# Build everything and test it.
+RUN make all
+RUN make test
+
+# Additional commands as necessary...

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(BUILD)/pgn.lex.c:
 
 $(PGN_SYNTAX_H): $(BUILD)/pgn.syntax.c
 
-$(BUILD)/pgn.syntax.c:
+$(BUILD)/pgn.syntax.c: $(BUILD) $(INCLUDE)
 	bison $(SRC)/pgn.syntax.y --header=$(PGN_SYNTAX_H) -o $@
 
 clean: $(INCLUDE) $(BUILD) $(BINDIR) $(LIBDIR)


### PR DESCRIPTION
Hi.

As discussed previously in code review.

* Fixes Makefile build error.
* Add basic Dockerfile to build and test.

Note that I couldn't get the tests to run from "make test", so that is also something to look into. I also see other make rules that could be useful to run in the image, like fuzzing and such.